### PR TITLE
Remove duplicate counters in German localization

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -106,8 +106,8 @@
     <!--Time-->
     <string name="minutes"> Minuten</string>
     <string name="minute"> Minute</string>
-    <string name="halfHour"> eine halbe Stunde</string>
-    <string name="hour"> einer Stunde</string>
+    <string name="halfHour"> halbe Stunde</string>
+    <string name="hour"> Stunde</string>
     <string name="threeQuartershour"> 45 Minuten</string>
     <string name="hourAndHalf"> 1:30 Stunden</string>
     <string name="hours"> Stunden</string>


### PR DESCRIPTION
die deutsche localization erzeugt Fehler in der Anzeige der Rest-Zeit bis der Raum frei wird.

"frei in **1 einer** Stunde"
"frei in **1 eine** halbe Stunde"
